### PR TITLE
Restrict vegafusion from installing 2rc

### DIFF
--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 0ce8c2e66546cb327e5f2d7572ec0e7c6feece816203215613962f0ec1d76a82
 
 build:
-  number: 2
+  number: 3
   noarch: python
 
 outputs:
@@ -62,7 +62,7 @@ outputs:
       run:
         - vl-convert-python >=1.6.0
         - pyarrow >=11
-        - vegafusion >=1.6.6, <2
+        - vegafusion >=1.6.6, <1.7
         - vegafusion-python-embed
         - anywidget >=0.9.0
         - {{ pin_subpackage('altair', exact=True) }}


### PR DESCRIPTION
It seems like the previous fix of <2 was not enough. I'm unsure how conda treats rc versions (maybe 2rc < 2?), but restricting vegafusion to max 1.7 will hopefully prevent the 2rc version from being installed.